### PR TITLE
Prevent iOS input focus-zoom + migrate pnpm settings to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,19 +102,5 @@
     "encoding": "^0.1.13",
     "serwist": "^9.1.1",
     "ts-node": "^10.9.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.0.12",
-      "@types/react-dom": "19.0.4"
-    },
-    "onlyBuiltDependencies": [
-      "@sentry/cli",
-      "@swc/core",
-      "@vercel/speed-insights",
-      "esbuild",
-      "sharp",
-      "unrs-resolver"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "wordle-teams",
   "version": "1.4.0",
   "private": true,
+  "packageManager": "pnpm@11.13.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+overrides:
+  '@types/react': 19.0.12
+  '@types/react-dom': 19.0.4
+allowBuilds:
+  '@sentry/cli': true
+  '@swc/core': true
+  '@vercel/speed-insights': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## What & why

Two small, independent changes:

### 1. Prevent iOS focus-zoom on text inputs (`fab6f72`)
Mobile Safari auto-zooms when you focus a text field whose `font-size` is below **16px**. The shared shadcn `Input` used `text-sm` (14px), so every text field zoomed on focus.

- Bumped the shared `Input` from `text-sm` → `text-base` (16px).
- All real text inputs (login email, create-team, complete-profile, points, etc.) flow through this one component, so this fixes them all.
- Did **not** touch the viewport meta (`user-scalable=no` / `maximum-scale`) — that would kill pinch-zoom and hurt accessibility. Raising the font size is the accessible fix.

Not affected: raw `<input>`s are all `hidden`, Radix `Select` is a button (no keyboard), and there's no textarea.

### 2. Migrate pnpm settings for pnpm 11 (`0f2f92e`)
pnpm 11 no longer reads the `"pnpm"` field in `package.json` (it warned on every command).

- Moved `overrides` to `pnpm-workspace.yaml`.
- Replaced the `onlyBuiltDependencies` allowlist with pnpm 11's `allowBuilds` map, approving the six native build scripts (`@sentry/cli`, `@swc/core`, `@vercel/speed-insights`, `esbuild`, `sharp`, `unrs-resolver`).
- Removed the dead `pnpm` field from `package.json`.

## Verification
- `pnpm install` runs clean under pnpm 11 with all native builds executing (no `ERR_PNPM_IGNORED_BUILDS`).
- `pnpm dev` boots with **zero warnings** (Ready in 3s).
- Lockfile unchanged (overrides were already present).

## Follow-up (not in this PR)
The `input-otp` login field's underlying input is transparent and inherits its font size — worth a real-iOS check on the OTP screen. If it zooms, add `text-base` to the `OTPInput` className.

🤖 Generated with [Claude Code](https://claude.com/claude-code)