### PR TITLE
Fix board-entry answer field iOS focus-zoom (14px → 16px)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 .specstory/*
 
 .cursor/*
+.env*

--- a/src/components/action-buttons/board-entry/form.tsx
+++ b/src/components/action-buttons/board-entry/form.tsx
@@ -142,7 +142,7 @@ export default function WordleBoardForm({ userId }: { userId: string }) {
             <div
               id="answer"
               ref={answerRef}
-              className="caret-transparent uppercase flex h-10 w-full rounded-md border border-input bg-background px-2 md:px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-4 focus:ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              className="caret-transparent uppercase flex h-10 w-full rounded-md border border-input bg-background px-2 md:px-3 py-2 text-base ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-4 focus:ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               tabIndex={2}
               onKeyDown={handleKeyDown}
               contentEditable={true}


### PR DESCRIPTION
## Why
Follow-up to #145. Testing the merged fix on `dev.wordleteams.com` in a mobile viewport showed the **board-entry "Wordle Answer" field still at 14px** and still triggering iOS focus-zoom.

## Root cause
That field isn't the shared shadcn `Input` — it's a `contentEditable` `<div>` (`board-entry/form.tsx`) that hand-copies the Input classes but hardcodes `text-sm` (14px). #145 only changed the `Input` component, so this element was untouched. iOS Safari zooms on focus of **any** editable element below 16px, `contentEditable` included.

## Fix
`text-sm` → `text-base` on the `#answer` field.

## Sweep (no other gaps)
- The sibling board-grid `contentEditable` (`wordle-board-input.tsx`) has **no** explicit font class and inherits the 16px root (no base font-size override in `globals.css`/`body`), so it was already zoom-safe.
- All other real text `<input>`s route through the now-fixed `Input`; remaining raw `<input>`s are `hidden`; `SelectTrigger` is a button.
- The login `input-otp` slots use `text-sm` on display divs; the real focused input inherits 16px — flagged for a real-device check but not changed here.

Second commit is an unrelated one-liner: gitignore `.env*` (auto-added by `vercel link`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)