### PR TITLE
Mobile UX: iOS focus-zoom fixes, keyboard-aware board entry, pnpm 11 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 .specstory/*
 
 .cursor/*
+.env*

--- a/docs/superpowers/plans/2026-07-15-mobile-board-entry-keyboard-aware-sheet.md
+++ b/docs/superpowers/plans/2026-07-15-mobile-board-entry-keyboard-aware-sheet.md
@@ -1,0 +1,394 @@
+# Keyboard-Aware Scrollable Mobile Board-Entry Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On mobile board entry, when the native keyboard is open, make all 6 guess rows finger-scrollable and keep Submit/Cancel visible above the keyboard, without regressing the desktop Dialog.
+
+**Architecture:** A `visualViewport`-driven React hook reports the visible area above the keyboard. The mobile `SheetContent` is bounded to that area and becomes a flex column: a scrollable region (header + board) plus a pinned footer (Cancel/Submit). An effect scrolls the active guess row into view as the user types. iOS Safari does not resize the layout viewport for the keyboard, so `visualViewport` — not `100dvh` — is the source of truth.
+
+**Tech Stack:** Next.js 15 (App Router), React 19, TypeScript, Tailwind CSS, Radix Dialog (via `ui/sheet.tsx`). No test framework exists in this repo; verification is `tsc --noEmit` + `pnpm lint` + on-device manual testing (matching existing conventions — introducing a test harness is out of scope).
+
+---
+
+## Testing note
+
+This repo has **no unit-test framework** (no vitest/jest, no `test` script; CI only runs a Supabase type-drift check). Per the writing-plans "follow existing patterns" rule, we do **not** add one for this UI change. Automated verification per task = TypeScript compile (`pnpm exec tsc --noEmit`) and lint (`pnpm lint`). Behavioral verification = the manual on-device checklist in Task 5.
+
+## File Structure
+
+- **Create** `src/lib/hooks/use-visual-viewport.tsx` — hook returning `{ height, offsetTop }` of the area above the keyboard. Single responsibility; mirrors the existing `use-media-query.tsx` pattern.
+- **Modify** `src/components/action-buttons/board-entry-button.tsx` — bound the mobile `SheetContent` to the visual viewport and make it a flex column.
+- **Modify** `src/components/action-buttons/board-entry/form.tsx` — wrap header + board in a scroll region, pin the footer as a flex child, add the active-row auto-scroll effect and board `onFocus` hook-up.
+- **Modify** `src/components/action-buttons/board-entry/wordle-board-input.tsx` — accept and attach an `onBoardFocus` callback so focusing the board scrolls the active row into view.
+
+Desktop is unaffected because `DialogContent` is a `grid` with no `max-height`: `flex-1`/`overflow-y-auto` are inert there, and the mobile footer is already `md:invisible md:h-0`.
+
+---
+
+### Task 1: `useVisualViewport` hook
+
+**Files:**
+- Create: `src/lib/hooks/use-visual-viewport.tsx`
+
+- [ ] **Step 1: Create the hook file**
+
+Create `src/lib/hooks/use-visual-viewport.tsx` with exactly:
+
+```tsx
+import * as React from 'react'
+
+export type VisualViewportState = {
+  height: number
+  offsetTop: number
+}
+
+function readViewport(): VisualViewportState {
+  if (typeof window === 'undefined') return { height: 0, offsetTop: 0 }
+  const vv = window.visualViewport
+  if (vv) return { height: vv.height, offsetTop: vv.offsetTop }
+  return { height: window.innerHeight, offsetTop: 0 }
+}
+
+/**
+ * Tracks the visual viewport (the area above the on-screen keyboard).
+ * iOS Safari does not shrink the layout viewport when the keyboard opens,
+ * but it does update `window.visualViewport`, so this is the reliable source
+ * of truth for bounding fixed overlays above the keyboard.
+ *
+ * Returns { height: 0, offsetTop: 0 } during SSR and { innerHeight, 0 } when
+ * the visualViewport API is unavailable.
+ */
+export function useVisualViewport(): VisualViewportState {
+  const [state, setState] = React.useState<VisualViewportState>(readViewport)
+
+  React.useEffect(() => {
+    const vv = window.visualViewport
+    const update = () => setState(readViewport())
+    update()
+
+    if (vv) {
+      vv.addEventListener('resize', update)
+      vv.addEventListener('scroll', update)
+      return () => {
+        vv.removeEventListener('resize', update)
+        vv.removeEventListener('scroll', update)
+      }
+    }
+
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+
+  return state
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: PASS (no errors). `window.visualViewport` is typed in the DOM lib; no extra types needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/hooks/use-visual-viewport.tsx
+git commit -m "feat: add useVisualViewport hook for keyboard-aware layout"
+```
+
+---
+
+### Task 2: Bound the mobile `SheetContent` to the visual viewport
+
+**Files:**
+- Modify: `src/components/action-buttons/board-entry-button.tsx`
+
+- [ ] **Step 1: Import the hook**
+
+At the top of `board-entry-button.tsx`, add the import alongside the existing `useMediaQuery` import:
+
+```tsx
+import { useMediaQuery } from '@/lib/hooks/use-media-query'
+import { useVisualViewport } from '@/lib/hooks/use-visual-viewport'
+```
+
+- [ ] **Step 2: Call the hook in the component**
+
+Inside `BoardEntryButton`, add the hook call next to the existing state (just below `const isDesktop = useMediaQuery('(min-width: 768px)')`):
+
+```tsx
+  const [open, setOpen] = useState(false)
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const { height, offsetTop } = useVisualViewport()
+```
+
+- [ ] **Step 3: Apply the bound + flex-column layout to the mobile `SheetContent`**
+
+Replace the mobile `SheetContent` opening tag:
+
+```tsx
+      <SheetContent side={'top'}>
+```
+
+with:
+
+```tsx
+      <SheetContent
+        side={'top'}
+        className='flex flex-col gap-0 overflow-hidden'
+        style={{ maxHeight: height || undefined, top: offsetTop }}
+      >
+```
+
+Notes:
+- `maxHeight: height || undefined` caps the sheet at the visible area when measured, and falls back to no cap (current behavior) when `height` is `0` (SSR / API missing).
+- `gap-0` neutralizes `SheetContent`'s base `gap-4`, which would otherwise activate once the element becomes `flex`.
+- `top: offsetTop` keeps the top-anchored sheet aligned to the visible area if iOS shifts the viewport (`offsetTop` is `0` in the normal case).
+
+- [ ] **Step 4: Typecheck and lint**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: PASS.
+Run: `pnpm lint`
+Expected: PASS (no new warnings/errors in this file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/action-buttons/board-entry-button.tsx
+git commit -m "feat: bound mobile board-entry sheet to visual viewport"
+```
+
+---
+
+### Task 3: Scroll region + pinned footer in the form
+
+**Files:**
+- Modify: `src/components/action-buttons/board-entry/form.tsx`
+
+- [ ] **Step 1: Make the form a flex column**
+
+Change the `<form>` opening tag (currently line ~118):
+
+```tsx
+    <form onSubmit={handleSubmit} className={cn(submitting ? 'animate-pulse' : '')}>
+```
+
+to:
+
+```tsx
+    <form onSubmit={handleSubmit} className={cn('flex flex-col min-h-0 flex-1', submitting ? 'animate-pulse' : '')}>
+```
+
+(`flex-1`/`min-h-0` are inert on desktop, where the `grid` `DialogContent` has no bounded height.)
+
+- [ ] **Step 2: Wrap header + board in a scroll region**
+
+The four `<input hidden .../>` elements stay directly under `<form>` (unchanged). Wrap the date/answer row `<div>` and the `<WordleBoardInput ... />` in a new scroll container. Concretely, insert an opening `<div className='flex-1 min-h-0 overflow-y-auto'>` immediately after the last hidden input (before `<div className="flex items-center space-x-4 ...">`), and a closing `</div>` immediately after the `<WordleBoardInput ... />` closing tag (before `<SheetFooter ...>`).
+
+Resulting structure (abbreviated — inner content of the date/answer div and WordleBoardInput props are unchanged):
+
+```tsx
+      <input hidden readOnly aria-readonly name="scoreId" value={scoreId} />
+      <input hidden readOnly aria-readonly name="scoreDate" value={date?.toISOString()} />
+      <input hidden readOnly aria-readonly name="guesses" value={guesses} />
+      <input hidden readOnly aria-readonly name="answer" value={answer} />
+      <div className='flex-1 min-h-0 overflow-y-auto'>
+        <div className="flex items-center space-x-4 md:space-x-4 w-full md:px-4 ml-2">
+          {/* ...existing date + answer content, unchanged... */}
+        </div>
+        <WordleBoardInput
+          guesses={guesses}
+          setGuesses={setGuesses}
+          answer={answer}
+          tabIndex={3}
+          submitting={submitting}
+          submitDisabled={submitDisabled}
+          scoreId={scoreId}
+        />
+      </div>
+      <SheetFooter className="pt-2 flex flex-row space-x-2 w-full shrink-0 bg-background md:invisible md:h-0 md:p-0">
+        {/* ...existing Cancel + Submit buttons, unchanged... */}
+      </SheetFooter>
+```
+
+- [ ] **Step 3: Pin the footer**
+
+In the `SheetFooter` className, add `shrink-0 bg-background` (shown above) so the footer keeps its height and paints a solid background at the bottom of the bounded flex column — i.e. directly above the keyboard. Do not remove the existing `md:invisible md:h-0 md:p-0` (keeps it hidden on desktop).
+
+- [ ] **Step 4: Typecheck and lint**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: PASS.
+Run: `pnpm lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/action-buttons/board-entry/form.tsx
+git commit -m "feat: scrollable board region + pinned footer in mobile board entry"
+```
+
+---
+
+### Task 4: Auto-scroll the active guess row into view
+
+**Files:**
+- Modify: `src/components/action-buttons/board-entry/form.tsx`
+- Modify: `src/components/action-buttons/board-entry/wordle-board-input.tsx`
+
+- [ ] **Step 1: Add the scroll helper + effect in `form.tsx`**
+
+`useEffect` is already imported in `form.tsx`. Add this helper and effect inside the `WordleBoardForm` component, above the `return`:
+
+```tsx
+  const scrollActiveRowIntoView = () => {
+    const activeIndex = guesses.findIndex((g) => g.length < 5)
+    const idx = activeIndex === -1 ? guesses.length - 1 : activeIndex
+    document.getElementById(`word-${idx}`)?.scrollIntoView({ block: 'nearest' })
+  }
+
+  useEffect(() => {
+    scrollActiveRowIntoView()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [guesses])
+```
+
+Rationale: `guesses` is the padded 6-element array; the first entry with `< 5` letters is the row being typed (mirrors `handleLetter` in `utils.ts`). When the board is full (`-1`), target the last row. `block: 'nearest'` avoids unnecessary jumps. Keyed on `guesses` only — the answer field lives at the top of the scroll region and stays visible, so answer edits do not trigger a board-row scroll.
+
+- [ ] **Step 2: Pass the focus callback to the board**
+
+Where `WordleBoardInput` is rendered in `form.tsx` (inside the new scroll region), add the `onBoardFocus` prop:
+
+```tsx
+        <WordleBoardInput
+          guesses={guesses}
+          setGuesses={setGuesses}
+          answer={answer}
+          tabIndex={3}
+          submitting={submitting}
+          submitDisabled={submitDisabled}
+          scoreId={scoreId}
+          onBoardFocus={scrollActiveRowIntoView}
+        />
+```
+
+- [ ] **Step 3: Accept and attach `onBoardFocus` in `wordle-board-input.tsx`**
+
+Add `onBoardFocus` to the props type:
+
+```tsx
+type WordleBoardProps = {
+  guesses: string[]
+  setGuesses: Dispatch<SetStateAction<string[]>>
+  answer: string
+  tabIndex?: number
+  submitting: boolean
+  submitDisabled: boolean
+  scoreId: number
+  onBoardFocus?: () => void
+}
+```
+
+Destructure it in the component signature:
+
+```tsx
+export default function WordleBoardInput({
+  guesses,
+  setGuesses,
+  answer,
+  tabIndex,
+  submitting,
+  submitDisabled,
+  scoreId,
+  onBoardFocus,
+}: WordleBoardProps) {
+```
+
+Attach it to the board `contentEditable` `<div>` by adding `onFocus={onBoardFocus}` to that element (the `<div contentEditable={true} onKeyDown={handleBoardKeyDown} ...>`):
+
+```tsx
+      <div
+        contentEditable={true}
+        onKeyDown={handleBoardKeyDown}
+        onFocus={onBoardFocus}
+        onChange={(e) => e.preventDefault()}
+        onInput={(e) => e.preventDefault()}
+        className='flex w-full h-fit justify-center mt-4 md:my-6 rounded-lg caret-transparent select-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-4 focus:ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:ring-offset-background'
+        role='region'
+        aria-label='Wordle Board'
+        tabIndex={tabIndex}
+      >
+```
+
+- [ ] **Step 4: Typecheck and lint**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: PASS.
+Run: `pnpm lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/action-buttons/board-entry/form.tsx src/components/action-buttons/board-entry/wordle-board-input.tsx
+git commit -m "feat: auto-scroll active guess row into view on board entry"
+```
+
+---
+
+### Task 5: Full verification (build + on-device)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Production build**
+
+Run: `pnpm build`
+Expected: build succeeds with no TypeScript/lint errors.
+
+- [ ] **Step 2: Deploy the branch to a Vercel preview for device testing**
+
+Push the branch and open a PR to `dev`:
+
+```bash
+git push -u origin feat/board-entry-keyboard-aware-sheet
+gh pr create --base dev --head feat/board-entry-keyboard-aware-sheet --title "Keyboard-aware scrollable mobile board-entry sheet" --body "Implements docs/superpowers/specs/2026-07-15-mobile-board-entry-keyboard-aware-sheet-design.md"
+```
+
+The PR gets a Vercel preview URL for on-device testing. (Note: merges to `dev` currently require a manual Vercel deploy trigger — see the parked auto-deploy investigation.)
+
+- [ ] **Step 3: Manual checklist — iOS Safari (primary), on the preview URL**
+
+Open board entry on a phone-sized viewport and confirm:
+- Focusing the answer field: no zoom; answer visible.
+- Focusing the board and typing guesses: the row being typed stays visible (auto-scrolls into view).
+- All 6 guess rows are reachable by finger-scroll while the keyboard is open.
+- Cancel and Submit stay visible and tappable above the keyboard at all times.
+- Dismissing the keyboard: the sheet expands back with no clipped/stuck state.
+
+- [ ] **Step 4: Manual checklist — Android Chrome**
+
+Repeat Step 3's flow; confirm equivalent behavior.
+
+- [ ] **Step 5: Manual checklist — desktop (≥768px)**
+
+Open board entry in the desktop Dialog; confirm layout and behavior are unchanged from before (no inner scrollbar, submit via the board's own button as today).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Goal (rows reachable, submit visible, auto-scroll active row, native keyboard kept, desktop unchanged) → Tasks 2-4, verified in Task 5. ✓
+- `useVisualViewport` hook w/ fallback → Task 1. ✓
+- Bound `SheetContent` mobile-only → Task 2. ✓
+- Scroll region + pinned footer, mobile-only via responsive classes → Task 3. ✓
+- Auto-scroll active row → Task 4. ✓
+- Edge cases (API missing fallback, keyboard close, orientation, desktop) → hook fallback (Task 1), flex `maxHeight` fallback (Task 2), verification (Task 5). ✓
+- Acceptance criteria 1-6 → covered by Tasks 2-5. ✓
+
+**Deviation from spec (intentional):** the spec described the footer as `position: sticky bottom-0`. The plan pins it via flexbox instead (footer is a `shrink-0` flex child at the bottom of the bounded flex column). Same visible outcome — footer above the keyboard — but more robust than `sticky` inside a `position: fixed` + `overflow` container on iOS. Auto-scroll is keyed on `guesses` + board `onFocus` (not answer focus), because the answer field sits at the top of the scroll region and is already visible; scrolling to a board row on answer focus would be wrong.
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `VisualViewportState { height, offsetTop }` used consistently in Tasks 1-2; `onBoardFocus?: () => void` defined and consumed consistently in Task 4. ✓

--- a/docs/superpowers/specs/2026-07-15-mobile-board-entry-keyboard-aware-sheet-design.md
+++ b/docs/superpowers/specs/2026-07-15-mobile-board-entry-keyboard-aware-sheet-design.md
@@ -1,0 +1,103 @@
+# Mobile Board-Entry: Keyboard-Aware Scrollable Sheet
+
+**Date:** 2026-07-15
+**Status:** Design — awaiting approval
+**Area:** `src/components/action-buttons/board-entry/*`, `src/components/action-buttons/board-entry-button.tsx`, `src/components/ui/sheet.tsx` (read-only reference), new `src/lib/hooks/`
+
+## Problem
+
+On mobile, board entry renders as a Radix Dialog–based `Sheet` with `side="top"` (`board-entry-button.tsx`). `SheetContent` is `position: fixed; top: 0`, auto-height, with **no internal scroll region**. Focusing the `contentEditable` answer/board fields summons the **native mobile keyboard**.
+
+On **iOS Safari**, opening the keyboard does **not** shrink the layout viewport (nor `100vh`/`100dvh`), so the fixed panel does not reflow. The result:
+
+- Only the first few of the 6 guess rows are visible; the rest — and the **Submit** button — sit *behind* the keyboard.
+- The user cannot reach them without dismissing the keyboard (Enter on the virtual keyboard).
+- Finger-scrolling does nothing: Radix locks body scroll and there is no `overflow-y: auto` region to scroll.
+
+This surfaced after the 16px font fix (which stopped the focus-zoom); the layout problem was previously masked by the zoom behavior.
+
+## Goal
+
+When the native keyboard is open on mobile board entry:
+
+- All 6 board rows are reachable via finger-scroll.
+- The **Submit** button (and Cancel) stay visible and tappable, pinned above the keyboard.
+- The row currently being typed into auto-scrolls into view.
+- The native keyboard is retained (the on-screen-keyboard approach was tried previously and abandoned due to quirks).
+- The desktop Dialog experience is unchanged.
+
+## Approach
+
+**Drive layout off the `visualViewport` API.** iOS Safari does not resize the layout viewport when the keyboard opens, but it *does* update `window.visualViewport` (`height` shrinks to the area above the keyboard; `offsetTop` reflects any viewport shift). We bound the sheet to that visible area and give it an internal scroll region plus a sticky footer.
+
+A CSS-only route (`interactive-widget=resizes-content` viewport meta + `100dvh`) was rejected: it only affects Android Chrome; iOS Safari ignores `interactive-widget`, so it does not fix the reported case.
+
+`side="top"` is retained — we only bound the panel's height/offset so it sits above the keyboard; the slide-from-top animation is unchanged.
+
+## Components & Changes
+
+### 1. New hook — `src/lib/hooks/use-visual-viewport.ts`
+
+Single-purpose, reusable, SSR-safe.
+
+- Reads `window.visualViewport`; subscribes to its `resize` and `scroll` events.
+- Returns `{ height, offsetTop }` describing the visible area above the keyboard.
+- Fallback when the API is unavailable: `{ height: window.innerHeight, offsetTop: 0 }`.
+- Cleans up listeners on unmount. Guards against `window`/`visualViewport` being undefined during SSR.
+
+**Interface:** `useVisualViewport(): { height: number; offsetTop: number }`
+**Depends on:** browser `visualViewport` API only.
+
+### 2. `board-entry-button.tsx` — mobile Sheet only
+
+- Call `useVisualViewport()` in the component.
+- On the mobile `<SheetContent side="top">`, apply an inline `style={{ height, top: offsetTop }}` and classes to make it a flex column that clips overflow (`flex flex-col overflow-hidden`), so its children own scrolling.
+- The desktop `<Dialog>` branch is left exactly as-is.
+
+### 3. `form.tsx` — mobile-only layout, via responsive classes
+
+- Wrap the header (date + answer) and the `WordleBoardInput` board in a scroll region: `flex-1 overflow-y-auto` (with appropriate `-webkit-overflow-scrolling` behavior). This is what restores finger-scroll and lets rows scroll into view.
+- Make the existing mobile `SheetFooter` (Cancel + Submit) `sticky bottom-0` with a solid `bg-background` (and top padding/border as needed) so it pins above the keyboard.
+- All changes are scoped to the mobile-visible elements; the desktop Dialog path (which uses `WordleBoardInput`'s own `md:visible` submit button and hides the `SheetFooter` via `md:invisible md:h-0`) is unaffected. Use `md:` variants where a class must not apply on desktop.
+
+### 4. Auto-scroll the active row — `form.tsx`
+
+- Each board row already renders with `id="word-${wordIndex}"` (`wordle-board.tsx`).
+- Compute the active row index = index of the first guess with fewer than 5 letters (mirrors `utils.ts` `handleLetter`).
+- In a `useEffect` keyed on `guesses` / `answer` (and on field focus), call `document.getElementById('word-' + activeIndex)?.scrollIntoView({ block: 'nearest' })`, scoped within the scroll region, so the row being typed stays visible without manual scrolling.
+
+## Data Flow
+
+`visualViewport` events → `useVisualViewport` state → inline height/offset on mobile `SheetContent` → flex column bounds the scroll region and pins the sticky footer. Typing updates `guesses`/`answer` → effect scrolls the active `#word-N` into view. No new global state, no network, no server changes.
+
+## Edge Cases
+
+- **`visualViewport` unavailable** (older browsers): fall back to `innerHeight`/`0`; the layout is still bounded and scrollable — degraded but functional.
+- **Keyboard dismissed:** hook reports full height; sheet expands back to normal. No stuck/clipped state.
+- **Orientation change / keyboard height change:** hook is reactive via `resize`; layout updates.
+- **Answer field vs. board field focus:** answer sits near the top and remains visible; board rows are handled by `scrollIntoView`.
+- **`position: fixed` + iOS keyboard quirk:** tracking `top: offsetTop` and `height` from `visualViewport` is the standard mitigation; verified on-device.
+- **Desktop / tablet ≥ 768px:** uses the Dialog, none of this applies. Explicitly verify no regression.
+
+## Testing / Verification
+
+- **Manual, iOS Safari (primary)** via `dev.wordleteams.com`: open board entry, focus the answer then the board; confirm all 6 rows are reachable by finger-scroll, Submit and Cancel stay visible and tappable, the active row auto-scrolls into view, and no focus-zoom occurs.
+- **Android Chrome:** sanity check the same flow.
+- **Desktop Dialog:** confirm unchanged.
+- **Optional unit test:** `useVisualViewport` fallback logic when `visualViewport` is undefined.
+
+## Out of Scope
+
+- On-screen keyboard (react-simple-keyboard) — previously abandoned.
+- Changing the sheet `side`.
+- Desktop Dialog layout.
+- The `dev`-branch auto-deploy investigation (tracked separately).
+
+## Acceptance Criteria
+
+1. On iOS Safari mobile board entry with the keyboard open, the user can finger-scroll to every one of the 6 guess rows.
+2. Submit and Cancel remain visible and tappable above the keyboard at all times while typing.
+3. The row currently being typed into is scrolled into view automatically.
+4. No focus-zoom regression (16px inputs preserved).
+5. The desktop Dialog board-entry experience is visually and behaviorally unchanged.
+6. When `visualViewport` is unavailable, the sheet still renders as a bounded, scrollable panel (no crash, no clipped-without-scroll state).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "wordle-teams",
   "version": "1.4.0",
   "private": true,
+  "packageManager": "pnpm@11.13.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -101,19 +101,5 @@
     "encoding": "^0.1.13",
     "serwist": "^9.1.1",
     "ts-node": "^10.9.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.0.12",
-      "@types/react-dom": "19.0.4"
-    },
-    "onlyBuiltDependencies": [
-      "@sentry/cli",
-      "@swc/core",
-      "@vercel/speed-insights",
-      "esbuild",
-      "sharp",
-      "unrs-resolver"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+overrides:
+  '@types/react': 19.0.12
+  '@types/react-dom': 19.0.4
+allowBuilds:
+  '@sentry/cli': true
+  '@swc/core': true
+  '@vercel/speed-insights': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true

--- a/src/components/action-buttons/board-entry-button.tsx
+++ b/src/components/action-buttons/board-entry-button.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTrigger } from '@/components/ui/sheet'
 import { useMediaQuery } from '@/lib/hooks/use-media-query'
+import { useVisualViewport } from '@/lib/hooks/use-visual-viewport'
 import { DialogClose } from '@radix-ui/react-dialog'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
@@ -20,6 +21,7 @@ import WordleBoardForm from './board-entry/form'
 export function BoardEntryButton({ userId }: { userId: string }) {
   const [open, setOpen] = useState(false)
   const isDesktop = useMediaQuery('(min-width: 768px)')
+  const { height, offsetTop } = useVisualViewport()
 
   if (isDesktop) {
     return (
@@ -51,7 +53,11 @@ export function BoardEntryButton({ userId }: { userId: string }) {
           <Plus size={20} />
         </Button>
       </SheetTrigger>
-      <SheetContent side={'top'}>
+      <SheetContent
+        side={'top'}
+        className='flex flex-col gap-0 overflow-hidden'
+        style={{ maxHeight: height || undefined, top: offsetTop }}
+      >
         <SheetHeader className='mt-4 mb-4 -ml-4'>
           <SheetDescription>Enter the day&apos;s answer and then your guesses</SheetDescription>
         </SheetHeader>

--- a/src/components/action-buttons/board-entry/form.tsx
+++ b/src/components/action-buttons/board-entry/form.tsx
@@ -142,7 +142,7 @@ export default function WordleBoardForm({ userId }: { userId: string }) {
             <div
               id="answer"
               ref={answerRef}
-              className="caret-transparent uppercase flex h-10 w-full rounded-md border border-input bg-background px-2 md:px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-4 focus:ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              className="caret-transparent uppercase flex h-10 w-full rounded-md border border-input bg-background px-2 md:px-3 py-2 text-base ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-4 focus:ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               tabIndex={2}
               onKeyDown={handleKeyDown}
               contentEditable={true}

--- a/src/components/action-buttons/board-entry/form.tsx
+++ b/src/components/action-buttons/board-entry/form.tsx
@@ -116,11 +116,12 @@ export default function WordleBoardForm({ userId }: { userId: string }) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className={cn(submitting ? 'animate-pulse' : '')}>
+    <form onSubmit={handleSubmit} className={cn('flex flex-col min-h-0 flex-1', submitting ? 'animate-pulse' : '')}>
       <input hidden readOnly aria-readonly name="scoreId" value={scoreId} />
       <input hidden readOnly aria-readonly name="scoreDate" value={date?.toISOString()} />
       <input hidden readOnly aria-readonly name="guesses" value={guesses} />
       <input hidden readOnly aria-readonly name="answer" value={answer} />
+      <div className="flex-1 min-h-0 overflow-y-auto">
       <div className="flex items-center space-x-4 md:space-x-4 w-full md:px-4 ml-2">
         <div id="wordle-board-date" className="flex flex-col w-[54%] md:w-full">
           <Label htmlFor="wordle-board-date" className="mb-2 text-xs sm:text-sm">
@@ -179,7 +180,8 @@ export default function WordleBoardForm({ userId }: { userId: string }) {
         submitDisabled={submitDisabled}
         scoreId={scoreId}
       />
-      <SheetFooter className="pt-2 flex flex-row space-x-2 w-full md:invisible md:h-0 md:p-0">
+      </div>
+      <SheetFooter className="pt-2 flex flex-row space-x-2 w-full shrink-0 bg-background md:invisible md:h-0 md:p-0">
         <SheetClose asChild>
           <Button variant="outline" className="w-full" id="close-board-entry">
             Cancel

--- a/src/components/action-buttons/board-entry/form.tsx
+++ b/src/components/action-buttons/board-entry/form.tsx
@@ -45,6 +45,7 @@ export default function WordleBoardForm({ userId }: { userId: string }) {
   const [submitDisabled, setSubmitDisabled] = useState(!boardIsValid(answer, guesses, scoreId))
   const [submitting, setSubmitting] = useState(false)
   const answerRef = useRef<HTMLDivElement>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const score = scores.find((s) => isSameDay(date!, parseISO(s.date)))
@@ -115,13 +116,24 @@ export default function WordleBoardForm({ userId }: { userId: string }) {
     }
   }
 
+  const scrollActiveRowIntoView = () => {
+    const activeIndex = guesses.findIndex((g) => g.length < 5)
+    const idx = activeIndex === -1 ? guesses.length - 1 : activeIndex
+    scrollContainerRef.current?.querySelector(`#word-${idx}`)?.scrollIntoView({ block: 'nearest' })
+  }
+
+  useEffect(() => {
+    scrollActiveRowIntoView()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [guesses])
+
   return (
     <form onSubmit={handleSubmit} className={cn('flex flex-col min-h-0 flex-1', submitting ? 'animate-pulse' : '')}>
       <input hidden readOnly aria-readonly name="scoreId" value={scoreId} />
       <input hidden readOnly aria-readonly name="scoreDate" value={date?.toISOString()} />
       <input hidden readOnly aria-readonly name="guesses" value={guesses} />
       <input hidden readOnly aria-readonly name="answer" value={answer} />
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div ref={scrollContainerRef} className="flex-1 min-h-0 overflow-y-auto">
       <div className="flex items-center space-x-4 md:space-x-4 w-full md:px-4 ml-2">
         <div id="wordle-board-date" className="flex flex-col w-[54%] md:w-full">
           <Label htmlFor="wordle-board-date" className="mb-2 text-xs sm:text-sm">
@@ -179,6 +191,7 @@ export default function WordleBoardForm({ userId }: { userId: string }) {
         submitting={submitting}
         submitDisabled={submitDisabled}
         scoreId={scoreId}
+        onBoardFocus={scrollActiveRowIntoView}
       />
       </div>
       <SheetFooter className="pt-2 flex flex-row space-x-2 w-full shrink-0 bg-background md:invisible md:h-0 md:p-0">

--- a/src/components/action-buttons/board-entry/wordle-board-input.tsx
+++ b/src/components/action-buttons/board-entry/wordle-board-input.tsx
@@ -14,6 +14,7 @@ type WordleBoardProps = {
   submitting: boolean
   submitDisabled: boolean
   scoreId: number
+  onBoardFocus?: () => void
 }
 
 export default function WordleBoardInput({
@@ -24,6 +25,7 @@ export default function WordleBoardInput({
   submitting,
   submitDisabled,
   scoreId,
+  onBoardFocus,
 }: WordleBoardProps) {
   const handleBoardKeyDown: KeyboardEventHandler = (e: KeyboardEvent<HTMLDivElement>) => {
     const key = e.key
@@ -40,6 +42,7 @@ export default function WordleBoardInput({
         onKeyDown={handleBoardKeyDown}
         onChange={(e) => e.preventDefault()}
         onInput={(e) => e.preventDefault()}
+        onFocus={onBoardFocus}
         className='flex w-full h-fit justify-center mt-4 md:my-6 rounded-lg caret-transparent select-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-4 focus:ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:ring-offset-background'
         role='region'
         aria-label='Wordle Board'

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/lib/hooks/use-visual-viewport.tsx
+++ b/src/lib/hooks/use-visual-viewport.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+
+export type VisualViewportState = {
+  height: number
+  offsetTop: number
+}
+
+function readViewport(): VisualViewportState {
+  if (typeof window === 'undefined') return { height: 0, offsetTop: 0 }
+  const vv = window.visualViewport
+  if (vv) return { height: vv.height, offsetTop: vv.offsetTop }
+  return { height: window.innerHeight, offsetTop: 0 }
+}
+
+/**
+ * Tracks the visual viewport (the area above the on-screen keyboard).
+ * iOS Safari does not shrink the layout viewport when the keyboard opens,
+ * but it does update `window.visualViewport`, so this is the reliable source
+ * of truth for bounding fixed overlays above the keyboard.
+ *
+ * Returns { height: 0, offsetTop: 0 } during SSR and { innerHeight, 0 } when
+ * the visualViewport API is unavailable.
+ */
+export function useVisualViewport(): VisualViewportState {
+  const [state, setState] = React.useState<VisualViewportState>(readViewport)
+
+  React.useEffect(() => {
+    const vv = window.visualViewport
+    const update = () => setState(readViewport())
+    update()
+
+    if (vv) {
+      vv.addEventListener('resize', update)
+      vv.addEventListener('scroll', update)
+      return () => {
+        vv.removeEventListener('resize', update)
+        vv.removeEventListener('scroll', update)
+      }
+    }
+
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+
+  return state
+}


### PR DESCRIPTION
## Summary

Promotes this session's mobile UX + tooling work to production. **Deliberately excludes** the pre-existing `opencode setup, sentry mcp` commit (`1fb44c5`) that was already sitting on `dev` — that stays on `dev` for separate promotion. This branch is `dev` minus exactly those 4 files (`next.config.js`, `opencode.json`, `package.json`'s `@sentry/mcp-server` line, and its `pnpm-lock.yaml` deps).

Three groups of changes:

### 1. iOS input focus-zoom fixes
- `ui/input.tsx` and the board-entry answer field: `text-sm` → `text-base` (14px → 16px).
- **Impact:** focusing a text field no longer triggers iOS Safari auto-zoom.

### 2. Keyboard-aware mobile board-entry sheet
- New `useVisualViewport` hook; the mobile `Sheet` is bounded to the area above the keyboard with an internal scroll region, a pinned Cancel/Submit footer, and auto-scroll of the active guess row.
- **Impact:** with the keyboard open, all 6 rows are finger-scrollable and Submit stays visible. Desktop Dialog unchanged.

### 3. pnpm 11 toolchain migration
- Moved settings to `pnpm-workspace.yaml` (`overrides` + `allowBuilds`), removed the dead `pnpm` package.json field, pinned `packageManager: pnpm@11.13.0`, ignore `.env*`.
- **Impact:** fixes the local pnpm warning and the Vercel build.
- **⚠️ Production dependency:** relies on `ENABLE_EXPERIMENTAL_COREPACK=1` (already set on the Vercel **Production** environment). This is the first prod build on pnpm 11 via corepack — worth watching.

## Files changed
`ui/input.tsx`, `board-entry-button.tsx`, `board-entry/form.tsx`, `board-entry/wordle-board-input.tsx`, `lib/hooks/use-visual-viewport.tsx` (new), `package.json`, `pnpm-workspace.yaml` (new), `.gitignore`, plus design/plan docs under `docs/superpowers/`.

## Verification
- Frozen `pnpm install` + `pnpm build` pass under pnpm 11.13.0 (Vercel parity).
- Same commits validated on-device via `dev.wordleteams.com` (keyboard-aware board entry confirmed working on iOS).
- `tsc --noEmit` + `pnpm lint` clean.

## Notes
- The `test` (Supabase type-drift) CI check is expected to fail — pre-existing/unrelated to this branch.
- The login `input-otp` field remains a theoretical (unverified) zoom spot; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)